### PR TITLE
Upgrade to modern Nodejs versions

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,14 @@
 /**
  * Cas
  */
-var _ = require('underscore'),
-    http = require('http'),
-    https = require('https'),
-    parseString = require('xml2js').parseString,
-    processors = require('xml2js/lib/processors'),
-    passport = require('passport'),
-    uuid = require('uuid/v4'),
-    util = require('util');
+const _ = require('underscore'),
+      http = require('http'),
+      https = require('https'),
+      parseString = require('xml2js').parseString,
+      processors = require('xml2js/lib/processors'),
+      passport = require('passport'),
+      { v4: uuidv4 } = require('uuid'),
+      util = require('util');
 
 function Strategy(options, verify) {
     if (typeof options == 'function') {


### PR DESCRIPTION
I don't expect this to be merged anytime soon, it's rather directed at people still using this.

Here are a bunch of changes to use:
- the new `URL()` constructor instead of the deprecated `url.*` (soon to be removed: https://github.com/nodejs/node/discussions/23694)
- use modern imports
- upgrade dependencies